### PR TITLE
I replace compile with implementation. Compile is deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ buildscript {
   }
 }
 
-compile('org.rabbit-converter.rabbit:rabbit:0.0.3') {
+implementation('org.rabbit-converter.rabbit:rabbit:0.0.3') {
   exclude group: 'org.json', module: 'json'
 }
 ```


### PR DESCRIPTION
I replace "compile" with "implementation" because Compile is deprecated.